### PR TITLE
fix: you'll own nothing and you'll be happy

### DIFF
--- a/.github/workflows/eas-build-bot.yml
+++ b/.github/workflows/eas-build-bot.yml
@@ -11,7 +11,7 @@ jobs:
     if: |
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/build') &&
-      github.event.comment.author_association == 'OWNER'
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR expands the EAS build bot trigger permissions from OWNER-only to include MEMBER, COLLABORATOR, and CONTRIBUTOR roles, making the `/build` command accessible to trusted team members.

**Changes:**
- Replaced single OWNER check with `contains()` function checking multiple roles
- Allows broader team access to trigger builds via PR comments

**Issues found:**
- Indentation error on line 14 (extra leading space)
- Comment on line 10 needs updating to reflect new permissions

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge after fixing the indentation syntax error on line 14
- The change is logical and well-intentioned (expanding permissions), but has a syntax error that must be corrected to ensure the workflow runs properly
- `.github/workflows/eas-build-bot.yml` line 14 requires indentation fix before merging

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/eas-build-bot.yml | Expanded build trigger permissions from OWNER to multiple roles; has indentation error on line 14 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant GitHub
    participant Workflow as EAS Build Bot
    participant EAS as Expo EAS
    
    User->>GitHub: Comment "/build" on PR
    GitHub->>Workflow: Trigger issue_comment event
    
    alt User is OWNER, MEMBER, COLLABORATOR, or CONTRIBUTOR
        Workflow->>GitHub: Post "Command received..."
        Workflow->>GitHub: Checkout PR code
        Workflow->>Workflow: Setup Bun & EAS
        Workflow->>Workflow: Install dependencies
        Workflow->>Workflow: Determine profile (prod/dev)
        Workflow->>EAS: Trigger build
        
        alt Build succeeds
            EAS-->>Workflow: Build URL
            Workflow->>GitHub: Post success with build URL
        else Build fails
            Workflow->>GitHub: Post failure message
        end
    else User lacks permissions
        Workflow->>Workflow: Skip (no action)
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->