### PR TITLE
fix: downgrade react-native-skia to 2.2.12 for Expo 54 compatibility

### DIFF
--- a/app/bun.lock
+++ b/app/bun.lock
@@ -30,7 +30,7 @@
         "@rn-primitives/toggle": "^1.2.0",
         "@rn-primitives/toggle-group": "^1.2.0",
         "@rn-primitives/tooltip": "^1.2.0",
-        "@shopify/react-native-skia": "^2.4.14",
+        "@shopify/react-native-skia": "2.2.12",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "expo": "^54.0.0",
@@ -575,7 +575,7 @@
 
     "@rn-primitives/utils": ["@rn-primitives/utils@1.2.0", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-web": "*" }, "optionalPeers": ["react-native", "react-native-web"] }, "sha512-vLXV5NuxIHDeb4Bw57FzdUh89/g8gz6GERm8TsbJaSUPsDXfnC/ffeYiZJb0LxNteKE3Nr8na4Jy2n26tFil7w=="],
 
-    "@shopify/react-native-skia": ["@shopify/react-native-skia@2.4.14", "", { "dependencies": { "canvaskit-wasm": "0.40.0", "react-reconciler": "0.31.0" }, "peerDependencies": { "react": ">=19.0", "react-native": ">=0.78", "react-native-reanimated": ">=3.19.1" }, "optionalPeers": ["react-native", "react-native-reanimated"], "bin": { "setup-skia-web": "scripts/setup-canvaskit.js" } }, "sha512-zFxjAQbfrdOxoNJoaOCZQzZliuAWXjFkrNZv2PtofG2RAUPWIxWmk2J/oOROpTwXgkmh1JLvFp3uONccTXUthQ=="],
+    "@shopify/react-native-skia": ["@shopify/react-native-skia@2.2.12", "", { "dependencies": { "canvaskit-wasm": "0.40.0", "react-reconciler": "0.31.0" }, "peerDependencies": { "react": ">=19.0", "react-native": ">=0.78", "react-native-reanimated": ">=3.19.1" }, "optionalPeers": ["react-native", "react-native-reanimated"], "bin": { "setup-skia-web": "scripts/setup-canvaskit.js" } }, "sha512-P5wZSMPTp00hM0do+awNFtb5aPh5hSpodMGwy7NaxK90AV+SmUu7wZe6NGevzQIwgFa89Epn6xK3j4jKWdQi+A=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.27.8", "", {}, "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="],
 

--- a/app/package.json
+++ b/app/package.json
@@ -38,7 +38,7 @@
         "@rn-primitives/toggle": "^1.2.0",
         "@rn-primitives/toggle-group": "^1.2.0",
         "@rn-primitives/tooltip": "^1.2.0",
-        "@shopify/react-native-skia": "^2.4.14",
+        "@shopify/react-native-skia": "2.2.12",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "expo": "^54.0.0",


### PR DESCRIPTION
Version 2.4.14 was missing native libraries (libsvg.a) causing EAS build failures

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Downgraded `@shopify/react-native-skia` from version 2.4.14 to 2.2.12 to resolve EAS build failures caused by missing native libraries (libsvg.a) in the newer version. The version is now pinned (without caret) to prevent automatic upgrades.

Changes:
- Downgraded `@shopify/react-native-skia` dependency in `package.json`
- Updated `bun.lock` to reflect the version change

The codebase uses Skia for image processing (RGB decoding in `lib/model/inference.ts:280-281` and overlay rendering in `app/results.tsx:5,147-235`). Verify that the `ImageFormat` export used in `results.tsx:235` is available in version 2.2.12, as this API may have been introduced in a later version.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with verification - the version downgrade fixes critical build failures
- The dependency downgrade is well-justified (fixes missing libsvg.a build failures) and minimal in scope. Score reduced from 5 to 4 due to potential API compatibility concerns with `ImageFormat` export in the older version - this should be verified through testing or build validation before merging.
- Verify `app/app/results.tsx` works correctly with the downgraded Skia version

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/package.json | Downgraded `@shopify/react-native-skia` from ^2.4.14 to 2.2.12 (pinned version) |
| app/bun.lock | Lockfile updated to reflect react-native-skia version downgrade |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant PM as Package Manager (Bun)
    participant EAS as EAS Build Service
    participant Skia as react-native-skia
    participant Native as Native Libraries

    Note over Dev,Native: Dependency Downgrade Flow

    Dev->>PM: Update package.json (2.4.14 → 2.2.12)
    PM->>PM: Resolve dependencies
    PM->>PM: Update bun.lock
    
    Dev->>EAS: Trigger EAS build
    EAS->>PM: Install dependencies
    PM->>Skia: Install react-native-skia@2.2.12
    Skia->>Native: Link native libraries
    
    alt Version 2.4.14 (Before)
        Native--xEAS: ❌ Missing libsvg.a
        EAS--xDev: Build Failed
    else Version 2.2.12 (After)
        Native-->>EAS: ✅ All libraries present
        EAS-->>Dev: Build Success
    end
    
    Note over Dev,Native: Version pinned to prevent auto-upgrade
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->