### PR TITLE
fix: add data.yaml to TFLite export for proper INT8 calibration

### DIFF
--- a/model/mina/export.py
+++ b/model/mina/export.py
@@ -34,10 +34,14 @@ def export_tflite(
     Raises:
         FileNotFoundError: If weights file not found
     """
+    from mina.train import get_data_yaml_path
+
     weights_path = Path(weights_path)
 
     if not weights_path.exists():
         raise FileNotFoundError(f"Weights file not found: {weights_path}")
+
+    data_yaml = get_data_yaml_path()
 
     print(f"Loading model from: {weights_path}")
     model = YOLO(str(weights_path))
@@ -49,6 +53,7 @@ def export_tflite(
     # used in YOLO NMS. NMS should be handled in the mobile app instead.
     export_path = model.export(
         format="tflite",
+        data=str(data_yaml),
         int8=int8,
         imgsz=imgsz,
         simplify=True,


### PR DESCRIPTION
Passes the fish disease dataset to TFLite export to ensure proper INT8 quantization calibration instead of using default COCO dataset. This fixes class information being lost during export.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes INT8 quantization calibration for TFLite export by passing the fish disease `data.yaml` to the export function. Previously, the export used YOLO's default COCO dataset for calibration, which caused fish disease class information to be lost during quantization. The fix imports `get_data_yaml_path()` from the train module and provides it to the `model.export()` call via the `data` parameter. This ensures INT8 calibration uses the correct fish disease dataset images and class labels.

- Imported `get_data_yaml_path()` function to retrieve dataset configuration
- Added `data` parameter to `model.export()` call with path to fish disease data.yaml
- No breaking changes; requires `data.yaml` to exist (created by `uv run mina-download`)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Clean bug fix with only 3 lines added. The change correctly addresses the issue of lost class information during INT8 quantization by providing the proper dataset configuration. The import is valid, error handling is appropriate (FileNotFoundError if data.yaml missing), and the fix aligns with YOLO's documented export API.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| model/mina/export.py | Added data.yaml parameter to TFLite export for proper INT8 calibration with fish disease dataset instead of default COCO |

</details>



<sub>Last reviewed commit: 8eed8ec</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->